### PR TITLE
Bug/Fix inability to skip/stop/fetchNowPlaying after skipping a song

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ builds/
 audio-cache/
 deployment-scripts/
 *.db
+*.log

--- a/voice/voice.go
+++ b/voice/voice.go
@@ -87,18 +87,19 @@ func (d *defaultMusicPlayer) PlayMusic(input chan []byte, guildID string, vc Cha
 		song = vc.GetBackupNext()
 	}
 
-	// LIFO, so we have to remove now playing before playing next
 	defer func() {
 		if aborted {
 			return
 		}
+
+		vc.RemoveNowPlaying()
+
 		if vc.ExistsNext() {
 			go d.PlayMusic(input, guildID, vc, true)
 		} else if vc.ExistsBackupNext() {
 			go d.PlayMusic(input, guildID, vc, false)
 		}
 	}()
-	defer ActiveVoiceChannels[guildID].RemoveNowPlaying()
 
 	encodeSession, err := dca.EncodeFile(ytmp3.PathToAudio(song.YoutubeID), dca.StdEncodeOptions)
 	if err != nil {

--- a/voice/voice_channels.go
+++ b/voice/voice_channels.go
@@ -72,6 +72,7 @@ func (vc *voiceChannel) IsPlayingMusic() bool {
 
 func (vc *voiceChannel) StopMusic() {
 	vc.AbortChannel <- "stop"
+	vc.RemoveNowPlaying()
 }
 
 func (vc *voiceChannel) SetNowPlaying(s *playlist.Song) {

--- a/voice/voice_channels_test.go
+++ b/voice/voice_channels_test.go
@@ -102,10 +102,14 @@ func TestRemoveNowPlaying(t *testing.T) {
 
 func TestStopMusic(t *testing.T) {
 	vc := voice.NewVoiceChannel()
+	s := &playlist.Song{}
+	vc.SetNowPlaying(s)
 
 	assert.Empty(t, vc.AbortChannel, "should be initially empty")
+	assert.True(t, vc.Playlist.IsPlayingMusic())
 	vc.StopMusic()
 	assert.NotEmpty(t, vc.AbortChannel, "should be not empty")
+	assert.False(t, vc.Playlist.IsPlayingMusic())
 }
 
 func TestIsPlayingMusic(t *testing.T) {


### PR DESCRIPTION
A concurrency issue caused the application to overwrite its `now_playing` state after skipping a song, causing problems with accessing the above features after skipping a song.